### PR TITLE
DRY __crand off and follow Liskov

### DIFF
--- a/esda/moran.py
+++ b/esda/moran.py
@@ -790,32 +790,43 @@ class Moran_Local(object):
                    (if permutations>0)
                    values indicate quandrant location 1 HH,  2 LH,  3 LL,  4 HL
     sim          : array (permutations by n)
-                   (if permutations>0 and w.n < LARGE)
                    I values for permuted samples
+                   If keep_simulations = False or the input data is very large, 
+                   this attribute will be None
+    rlisa        : array (permutations by n)
+                   I values for permuted samples (same as sim)
+                   If keep_simulations = False or the input data is very large, 
+                   this attribute will be None
     p_sim        : array
-                   (if permutations>0)
-                   p-values based on permutations (one-sided)
+                   p-values based on permutations (one-sided). 
                    null: spatial randomness
                    alternative: the observed Ii is further away or extreme
                    from the median of simulated values. It is either extremely
                    high or extremely low in the distribution of simulated Is.
+                   If `keep_simulations = False`, `permutations < 1`,
+                   or the input data is very large, this attribute will be numpy.nan
     EI_sim       : array
-                   (if permutations>0 and w.n < LARGE)
-                   average values of local Is from permutations
+                   average values of local Is from permutations. 
+                   If `keep_simulations = False`, `permutations < 1`,
+                   or the input data is very large, this attribute will be numpy.nan
     VI_sim       : array
-                   (if permutations>0 and w.n < LARGE)
-                   variance of Is from permutations
+                   variance of Is from permutations. 
+                   If `keep_simulations = False`, `permutations < 1`,
+                   or the input data is very large, this attribute will be numpy.nan
     seI_sim      : array
-                   (if permutations>0 and w.n < LARGE)
                    standard deviations of Is under permutations.
+                   If `keep_simulations = False`, `permutations < 1`,
+                   or the input data is very large, this attribute will be numpy.nan
     z_sim        : arrray
-                   (if permutations>0 and w.n < LARGE)
-                   standardized Is based on permutations
+                   standardized Is based on permutations. 
+                   If `keep_simulations = False`, `permutations < 1`,
+                   or the input data is very large, this attribute will be numpy.nan
     p_z_sim      : array
-                   (if permutations>0 and w.n < LARGE)
                    p-values based on standard normal approximation from
-                   permutations (one-sided)
+                   permutations (one-sided). 
                    for two-sided tests, these values should be multiplied by 2
+                   If `keep_simulations = False`, `permutations < 1`,
+                   or the input data is very large, this attribute will be numpy.nan
 
     Notes
     -----


### PR DESCRIPTION
Hey, this does two things. 
1. push the code for `__crand_lite` back into `__crand`. 

We should try to keep the code as concise as possible... copy-pasting these routines is a recipe for bugs to get fixed in one instance but not elsewhere. So, here, we only build the big permutation matrix if `keep_simulations=True`, and then otherwise behave like `__crand_lite` did. This adds one boolean check per observation, which I bet will not be the significant slowdown for this routine (`np.random.permutation` is!)

2. follow the Liskov princple

The [LSP](https://en.wikipedia.org/wiki/SOLID) says that subclasses should be interchangeable with their parent class. A clear implication of this is that *two members of the same class* should be interchangeable. This means that their attributes (and ideally, the types of their attributes) should be the same. However, the *values* of these attributes may be very different. 

Here, we need to keep the same attributes on a `Moran_Local` object, even if we don't keep the simulation distribution. This means that (I think) we should set the numerics obtained from simulation to `numpy.nan` (or another missing value) and the simulation distributions (`sim` and `rlisas`, not sure why we have two names for the same value) to `None`. 

Since this is larger than the stuff I pushed for geary, I wanted to make a specific PR here rather than just push it on top of your code. 